### PR TITLE
Add `rotatetheta()`

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -4,6 +4,8 @@ on:
   create:
     tags:
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -4,8 +4,6 @@ on:
   create:
     tags:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlochSim"
 uuid = "5c0f8cbe-99a4-11e9-108b-216da9629524"
 authors = ["Steven Whitaker <stwhit@umich.edu>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/excite.jl
+++ b/src/excite.jl
@@ -145,15 +145,15 @@ function ExcitationWorkspace(
 end
 
 """
-    rotatetheta!(A, θ, α)
+    rotatetheta!(A, α, θ)
 
 Simulate left-handed rotation by angle `α` about an axis in the x-y plane that
 makes angle `θ` with the negative y-axis, overwriting `A`.
 """
-function rotatetheta!(A, θ, α)
+function rotatetheta!(A, α, θ)
 
-    (sinθ, cosθ) = sincos(θ)
     (sinα, cosα) = sincos(α)
+    (sinθ, cosθ) = sincos(θ)
 
     A.a11 = sinθ^2 + cosα * cosθ^2
     A.a21 = sinθ * cosθ - cosα * sinθ * cosθ
@@ -167,6 +167,19 @@ function rotatetheta!(A, θ, α)
 
     return nothing
 
+end
+
+"""
+    rotatetheta(α::Real = π/2, θ::Real = 0)
+Return `3 × 3` `BlochMatrix`
+for (left handed) flip angle `α`
+about an axis in the x-y plane that
+makes angle `θ` with the negative y-axis.
+"""
+function rotatetheta(α::Real = π/2, θ::Real = 0)
+    A = BlochMatrix()
+    rotatetheta!(A, α, θ)
+    return A
 end
 
 """
@@ -215,7 +228,7 @@ Simulate excitation, overwriting `A` and `B` (in-place version of
 """
 function excite!(A::ExcitationMatrix, spin::AbstractSpin, rf::InstantaneousRF)
 
-    rotatetheta!(A.A, rf.θ, rf.α)
+    rotatetheta!(A.A, rf.α, rf.θ)
 
 end
 

--- a/test/excite.jl
+++ b/test/excite.jl
@@ -1,3 +1,5 @@
+using BlochSim: rotatetheta
+
 function excite1()
 
     θ = π/4
@@ -135,5 +137,7 @@ end
     @test excitemc1()
     @test excitemc2()
     @test excitemc3()
+
+    @test Matrix(rotatetheta()) ≈ [0 0 1; 0 1 0; -1 0 0]
 
 end


### PR DESCRIPTION
The impetus here is to add a `rotatetheta()` method so someone (e.g., me) can see what is going on there easily.
The breaking change is to reverse the argument order to make it `α, θ` so that it is consistent with the (alphabetical!) order used in `InstantaneousRF`.
I did not export it because it seems mainly for development and debugging work...
