### PR TITLE
Explore finite RF duration, add BlochMatrix helpers

### DIFF
--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -302,67 +302,6 @@ crb_std = sqrt.(diag(crb))
 cov1 = round.(crb_std ./ x ; digits=3) # coefficient of variation
 
 
-
-#=
-## RF pulse duration
-The preceding calculations were all
-for hypothetical instantaneous" RF pulses.
-
-Examine effects of finite RF pulse duration
-for a spin with a relatively short T2.
-=#
-
-Mz0, T1_ms, T2_ms, Δf_Hz = 1, 400, 40, 0 # tissue parameters
-TR_ms, TE_ms, α_rad = 8, 4, deg2rad(50) # scan parameters
-
-Δϕ_rad = range(-1,1,101) * π
-rf0 = InstantaneousRF(α_rad)
-_bssfp(Δϕ_rad, rf) = bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ_rad, rf);
-
-#=
-Specify finite-duration hard (rectangular) RF pulse
-- `GAMMA` has units rad/s/G
-- Tip angle for constant pulse:
-  `α_rad = GAMMA * b1_gauss * tRF_s`
-- so `b1_gauss = α_rad / GAMMA / tRF_s`
-=#
-#src tRF_ms = 1e-12 # super-short for first test
-tRF_ms = 1
-waveform1 = [1] * α_rad / (tRF_ms / 1000) / GAMMA # single sample i.e. instant!
-rf1 = RF(waveform1, tRF_ms)
-signal0 = map(Δϕ -> _bssfp(Δϕ, rf0), Δϕ_rad)
-signal1 = map(Δϕ -> _bssfp(Δϕ, rf1), Δϕ_rad)
-@assert signal0 ≈ signal1
-@assert α_rad == rf0.α ≈ only(rf1.α)
-
-# Plot
-prfm = plot(
- xlabel = "phase cycling increment Δϕ (rad)",
- ylabel = "bSSFP signal mag",
-)
-prfa = plot(
- xlabel = "phase cycling increment Δϕ (rad)",
- ylabel = "bSSFP signal phase",
-)
-plot!(prfm, Δϕ_rad, abs.(signal0), label="Instantaneous")
-plot!(prfa, Δϕ_rad, angle.(signal0), label="Instantaneous")
-#src plot!(Δϕ_rad, abs.(signal1), label="tRF = $tRF_ms")
-nw = 1000 # approximately 1μs dwell time
-for tRF_ms in [1e-2 1 2]
-    waveform2 = ones(nw) * α_rad / (tRF_ms / 1000) / GAMMA
-    rf2 = RF(waveform2, tRF_ms/nw)
-    @assert rf0.α ≈ sum(rf2.α)
-    signal2 = map(Δϕ -> _bssfp(Δϕ, rf2), Δϕ_rad)
-    local label = "tRF = $tRF_ms ms, nw=$nw"
-    plot!(prfm, Δϕ_rad, abs.(signal2); label)
-    plot!(prfa, Δϕ_rad, angle.(signal2); label)
-end;
-
-prf = plot(prfm, prfa, layout=(2,1),
- plot_title="RF pulse duration effect, T2=$T2_ms (ms)")
-
-
-
 #=
 ## Multi-compartment spins and myelin water exchange
 
@@ -639,7 +578,7 @@ p_m = plot(title="Signal Magnitude vs. Scan Index", ylabel = "Signal Magnitude")
 p_p = plot(title="Signal Phase vs. Scan Index", ylabel = "Signal Phase")
 for j = 1:length(signal) # iterate over exchange values
     markershape = tau_arr_marker[j]
-    local label = latexstring("\$τ_{\\mathrm{fs}}\$ = $τ_fs ms")
+    local label = latexstring("\$τ_{\\mathrm{fs}}\$ = $(tau_arr_ms[j]) ms")
     plot!(p_m, scan_idx, abs.(signal[j]), linewidth=0; markershape, label)
     plot!(p_p, scan_idx, angle.(signal[j]), linewidth=0; markershape, label)
 end

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -1,0 +1,164 @@
+#=
+# [bSSFP RF Duration](@id bssfp-rf-dur)
+
+This page illustrates using the Julia package
+[`BlochSim`](https://github.com/StevenWhitaker/BlochSim.jl)
+to calculate MRI signals
+for
+balanced steady-state free precession
+[(bSSFP)](https://en.wikipedia.org/wiki/Steady-state_free_precession_imaging)
+pulse sequences.
+
+Specifically it examines the effects of finite RF duration.
+
+
+### References
+
+- todo
+
+=#
+
+#srcURL
+
+
+#=
+### Setup
+
+First we add the Julia packages that are need for this demo.
+Change `false` to `true` in the following code block
+if you are using any of the following packages for the first time.
+=#
+
+if false
+    import Pkg
+    Pkg.add([
+        "BlochSim"
+        "ForwardDiff"
+        "InteractiveUtils"
+        "LaTeXStrings"
+        "LinearAlgebra"
+        "MIRTjim"
+        "Plots"
+    ])
+end
+
+
+# Tell this Julia session to use the following packages for this example.
+# Run `Pkg.add()` in the preceding code block first, if needed.
+
+using BlochSim: Spin, SpinMC, InstantaneousRF, RF, excite
+#src using BlochSim: bSSFPellipse
+using BlochSim: bssfp, GAMMA
+#src import ForwardDiff
+#src using LaTeXStrings: latexstring
+#src using LinearAlgebra: Diagonal, I, cond, diag, norm
+using MIRTjim: prompt
+using Plots: gui, plot, plot!, default
+default(titlefontsize = 10, markerstrokecolor = :auto, label="", width = 1.5)
+
+
+# The following line is helpful when running this file as a script;
+# this way it will prompt user to hit a key after each figure is displayed.
+
+isinteractive() || prompt(:draw);
+
+
+#=
+## RF pulse duration effects for 1-pool model
+
+Examine effects of finite RF pulse duration
+for a single spin with a relatively short T2.
+=#
+
+Mz0, T1_ms, T2_ms, Δf_Hz = 1, 400, 40, 0 # tissue parameters
+α_deg = 50 # flip angle
+TR_ms, TE_ms, α_rad = 8, 4, deg2rad(α_deg) # scan parameters
+spin = Spin(Mz0, T1_ms, T2_ms, Δf_Hz)
+
+Δϕ_rad = range(-1, 1, 101) * π # phase-cycling factors
+_bssfp(Δϕ, rf) = bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ, rf)
+_bssfp(rf) = map(Δϕ -> _bssfp(Δϕ, rf), Δϕ_rad) # helper
+
+rf0 = InstantaneousRF(α_rad)
+signal0 = _bssfp(rf0) # InstantaneousRF signal
+
+
+#=
+Specify finite-duration (rectangular) RF pulse
+- `GAMMA` has units rad/s/G
+- Tip angle for constant pulse:
+  `α_rad = GAMMA * b1_gauss * tRF_s`
+- so `b1_gauss = α_rad / GAMMA / tRF_s`
+=#
+b1_gauss(α_rad, tRF_ms) = α_rad / GAMMA / (tRF_ms / 1000)
+
+
+#=
+### Test "nearly instantaneous" RF pulse
+=#
+tRF_ms = 1e-12 # super-short for first test
+waveform1 = [1] * b1_gauss(α_rad, tRF_ms) # single sample i.e. instant!
+rf1 = RF(waveform1, tRF_ms)
+signal1 = _bssfp(rf1)
+@assert signal0 ≈ signal1 # should be essentially identical
+@assert α_rad == rf0.α ≈ only(rf1.α)
+
+
+#=
+### Test 2ms RF pulse
+Somewhat unexpectedly (to JF),
+the signal matches the instantaneous RF case,
+because `excite!` for a `RF` type uses `freeprecess!`
+for each sample and here there is just a single sample.
+=#
+tRF_ms = 2
+waveform2 = [1] * b1_gauss(α_rad, tRF_ms) # single sample i.e. instant!
+rf2 = RF(waveform2, tRF_ms)
+signal2 = _bssfp(rf2)
+@assert signal0 ≈ signal2 # matches!?
+@assert α_rad == rf0.α ≈ only(rf2.α)
+
+
+#=
+Examine excitation matrices
+=#
+A0, B0 = excite(spin, rf0)
+A1, B1 = excite(spin, rf1)
+@assert B0 === nothing
+@assert maximum(abs, Vector(B1)) ≤ 3e-15 # 15*eps()
+@assert Matrix(A0) ≈ Matrix(A1)
+
+A2, B2 = excite(spin, rf2)
+@assert !(Matrix(A1) ≈ Matrix(A2)) # huh!?
+Matrix(A1) - Matrix(A2)
+
+#=
+A1 and A2 differ, so why are is signal0 ≈ signal2
+=#
+
+
+# Plot
+xaxis = ("phase cycling increment Δϕ (rad)", (-π, π), ((-1:1).*π, ["-π", "0", "π"]))
+prfm = plot( ; xaxis, ylabel = "bSSFP signal mag",)
+prfa = plot( ; xaxis, ylabel = "bSSFP signal phase",)
+
+plot!(prfm, Δϕ_rad, abs.(signal0), label="Instantaneous")
+plot!(prfa, Δϕ_rad, angle.(signal0), label="Instantaneous")
+
+#src plot!(Δϕ_rad, abs.(signal1), label="tRF = $tRF_ms")
+nw = 1000 # approximately 1μs dwell time
+for tRF_ms in [1e-2 1 2]
+    waveform4 = ones(nw) * b1_gauss(α_rad, tRF_ms)
+    rf4 = RF(waveform4, tRF_ms / nw)
+    @assert rf0.α ≈ sum(rf4.α)
+    signal4 = _bssfp(rf4)
+    label = "tRF = $tRF_ms ms, nw=$nw"
+    plot!(prfm, Δϕ_rad, abs.(signal4); label)
+    plot!(prfa, Δϕ_rad, angle.(signal4); label)
+end;
+
+prf = plot(prfm, prfa, layout=(2,1),
+ plot_title = "RF pulse duration effect, T2=$T2_ms (ms)")
+
+
+# todo include("../../../inc/reproduce.jl")

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -9,7 +9,7 @@ balanced steady-state free precession
 [(bSSFP)](https://en.wikipedia.org/wiki/Steady-state_free_precession_imaging)
 pulse sequences.
 
-Specifically it examines the effects of finite RF duration.
+Specifically it examines the effects of finite RF pulse duration.
 
 
 ### References

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -47,11 +47,8 @@ end
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using BlochSim: Spin, SpinMC, InstantaneousRF, RF, excite
-#src using BlochSim: bSSFPellipse
 using BlochSim: bssfp, GAMMA
-#src import ForwardDiff
-#src using LaTeXStrings: latexstring
-#src using LinearAlgebra: Diagonal, I, cond, diag, norm
+#src import ForwardDiff # todo: later
 using MIRTjim: prompt
 using Plots: gui, plot, plot!, default
 default(titlefontsize = 10, markerstrokecolor = :auto, label="", width = 1.5)
@@ -80,16 +77,18 @@ _bssfp(Δϕ, rf) = bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ, rf)
 _bssfp(rf) = map(Δϕ -> _bssfp(Δϕ, rf), Δϕ_rad) # helper
 
 rf0 = InstantaneousRF(α_rad)
-signal0 = _bssfp(rf0) # InstantaneousRF signal
+signal0 = _bssfp(rf0) # signal for InstantaneousRF
 
 
-#=
-Specify finite-duration (rectangular) RF pulse
+"""
+    b1_gauss(α_rad, tRF_ms)
+
+Return finite-duration (rectangular) RF pulse amplitude
 - `GAMMA` has units rad/s/G
 - Tip angle for constant pulse:
   `α_rad = GAMMA * b1_gauss * tRF_s`
 - so `b1_gauss = α_rad / GAMMA / tRF_s`
-=#
+"""
 b1_gauss(α_rad, tRF_ms) = α_rad / GAMMA / (tRF_ms / 1000)
 
 
@@ -97,50 +96,47 @@ b1_gauss(α_rad, tRF_ms) = α_rad / GAMMA / (tRF_ms / 1000)
 ### Test "nearly instantaneous" RF pulse
 =#
 tRF_ms = 1e-12 # super-short for first test
-waveform1 = [1] * b1_gauss(α_rad, tRF_ms) # single sample i.e. instant!
+waveform1 = [1] * b1_gauss(α_rad, tRF_ms) # single sample, i.e., "instant"
 rf1 = RF(waveform1, tRF_ms)
-#=
 signal1 = _bssfp(rf1)
 @assert signal0 ≈ signal1 # should be essentially identical
 @assert α_rad == rf0.α ≈ only(rf1.α)
-=#
 
 
 #=
 ### Test 2ms RF pulse
 Somewhat unexpectedly (to JF),
-the signal matches the instantaneous RF case,
+the signal matches the `InstantaneousRF` case,
 because `excite!` for a `RF` type uses `freeprecess!`
 for each sample and here there is just a single sample.
 =#
 tRF_ms = 2
-waveform2 = [1] * b1_gauss(α_rad, tRF_ms) # single sample i.e. instant!
+waveform2 = [1] * b1_gauss(α_rad, tRF_ms) # single sample, i.e., "instant!?"
 rf2 = RF(waveform2, tRF_ms)
-#=
 signal2 = _bssfp(rf2)
-@assert signal0 ≈ signal2 # matches!?
+@assert signal0 ≈ signal2 # todo: matches!?
 @assert α_rad == rf0.α ≈ only(rf2.α)
-=#
 
 
 #=
 Examine excitation matrices
+for different RF types.
 =#
 A0, B0 = excite(spin, rf0)
 A1, B1 = excite(spin, rf1)
 @assert B0 === nothing
 @assert maximum(abs, Vector(B1)) ≤ 3e-15 # 15*eps()
-@assert Matrix(A0) ≈ Matrix(A1)
+@assert Matrix(A0) ≈ Matrix(A1) # similar as expected for super-short RF
 
 A2, B2 = excite(spin, rf2)
 @assert !(Matrix(A1) ≈ Matrix(A2)) # huh!?
 Matrix(A1) - Matrix(A2)
 
-@which excite(spin, rf2)
-throw()
+#src todo: study more
+#src @which excite(spin, rf2) see excite!(A, ...) with "todo" in excite.jl
 
 #=
-A1 and A2 differ, so why are is signal0 ≈ signal2
+todo: A1 and A2 differ, so why are is signal0 ≈ signal2
 =#
 
 
@@ -167,5 +163,4 @@ end;
 prf = plot(prfm, prfa, layout=(2,1),
  plot_title = "RF pulse duration effect, T2=$T2_ms (ms)")
 
-
-# todo include("../../../inc/reproduce.jl")
+#src todo include("../../../inc/reproduce.jl")

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -99,9 +99,11 @@ b1_gauss(α_rad, tRF_ms) = α_rad / GAMMA / (tRF_ms / 1000)
 tRF_ms = 1e-12 # super-short for first test
 waveform1 = [1] * b1_gauss(α_rad, tRF_ms) # single sample i.e. instant!
 rf1 = RF(waveform1, tRF_ms)
+#=
 signal1 = _bssfp(rf1)
 @assert signal0 ≈ signal1 # should be essentially identical
 @assert α_rad == rf0.α ≈ only(rf1.α)
+=#
 
 
 #=
@@ -114,9 +116,11 @@ for each sample and here there is just a single sample.
 tRF_ms = 2
 waveform2 = [1] * b1_gauss(α_rad, tRF_ms) # single sample i.e. instant!
 rf2 = RF(waveform2, tRF_ms)
+#=
 signal2 = _bssfp(rf2)
 @assert signal0 ≈ signal2 # matches!?
 @assert α_rad == rf0.α ≈ only(rf2.α)
+=#
 
 
 #=
@@ -131,6 +135,9 @@ A1, B1 = excite(spin, rf1)
 A2, B2 = excite(spin, rf2)
 @assert !(Matrix(A1) ≈ Matrix(A2)) # huh!?
 Matrix(A1) - Matrix(A2)
+
+@which excite(spin, rf2)
+throw()
 
 #=
 A1 and A2 differ, so why are is signal0 ≈ signal2

--- a/src/blochmatrix.jl
+++ b/src/blochmatrix.jl
@@ -1,9 +1,10 @@
 abstract type AbstractBlochMatrix{T<:Real} end
 
 """
-    BlochMatrix(a11, a21, a31, a12, a22, a32, a13, a23, a33)
-    BlochMatrix{T}()
-    BlochMatrix()
+    BlochMatrix(a11, a21, a31, a12, a22, a32, a13, a23, a33) # from scalars
+    BlochMatrix(A::AbstractMatrix) # construct from 3×3 matrix
+    BlochMatrix{T}() # zeros of type `T`
+    BlochMatrix() # zeros of type `Float64`
 
 Create a mutable `BlochMatrix` object representing a fixed-size 3×3 matrix.
 
@@ -22,10 +23,25 @@ mutable struct BlochMatrix{T<:Real} <: AbstractBlochMatrix{T}
     a33::T
 end
 
-BlochMatrix(a...) = BlochMatrix(promote(a...)...)
+
+# Constructors
+
+BlochMatrix(A::AbstractMatrix) = BlochMatrix(vec(A)...)
+
+BlochMatrix(t::NTuple{9}) = BlochMatrix(t...)
+
+# caution: the following would stack overflow for BlochMatrix(1, 2, 3)
+# BlochMatrix(a...) = BlochMatrix(promote(a...)...)
+BlochMatrix(a, b, c, d, e, f, g, h, i) =
+    BlochMatrix(promote(a, b, c, d, e, f, g, h, i))
+
 BlochMatrix{T}() where {T} = BlochMatrix(zero(T), zero(T), zero(T), zero(T),
                                     zero(T), zero(T), zero(T), zero(T), zero(T))
+
 BlochMatrix() = BlochMatrix{Float64}()
+
+
+# Helpers
 
 function Base.show(io::IO, ::MIME"text/plain", A::BlochMatrix{T}) where {T}
 
@@ -81,6 +97,7 @@ function Base.copyto!(dst::BlochMatrix, src::BlochMatrix)
 
 end
 
+
 function Base.Matrix(A::BlochMatrix{T}) where {T}
 
     mat = Matrix{T}(undef, 3, 3)
@@ -97,6 +114,7 @@ function Base.Matrix(A::BlochMatrix{T}) where {T}
     return mat
 
 end
+
 
 """
     BlochDynamicsMatrix(R1, R2, Δω)
@@ -139,6 +157,7 @@ function Base.Matrix(A::BlochDynamicsMatrix{T}) where {T}
     return mat
 
 end
+
 
 """
     FreePrecessionMatrix(E1, E2, θ)

--- a/src/excite.jl
+++ b/src/excite.jl
@@ -5,11 +5,12 @@ Abstract type for representing radiofrequency (RF) pulses.
 """
 abstract type AbstractRF end
 
+
 """
     InstantaneousRF(α, θ = 0) <: AbstractRF
 
-Represents an idealized instantaneous RF pulse with flip angle `α` and phase
-`θ`.
+Represent an idealized instantaneous RF pulse
+with flip angle `α` and phase `θ`.
 """
 struct InstantaneousRF{T<:Real} <: AbstractRF
     α::T
@@ -18,9 +19,12 @@ end
 
 InstantaneousRF(α, θ = zero(α)) = InstantaneousRF(promote(α, θ)...)
 
-Base.show(io::IO, rf::InstantaneousRF) = print(io, "InstantaneousRF(", rf.α, ", ", rf.θ, ")")
+Base.show(io::IO, rf::InstantaneousRF) =
+     print(io, "InstantaneousRF(", rf.α, ", ", rf.θ, ")")
 Base.show(io::IO, ::MIME"text/plain", rf::InstantaneousRF{T}) where {T} =
-    print(io, "Instantaneous RF pulse with eltype $T:\n α = ", rf.α, " rad\n θ = ", rf.θ, " rad")
+    print(io, "Instantaneous RF pulse with eltype $T:\n α = ", rf.α,
+        " rad\n θ = ", rf.θ, " rad")
+
 
 """
     RF(waveform, Δt, [Δθ], [grad]) <: AbstractRF
@@ -47,7 +51,7 @@ and time step `Δt` (ms).
   - `::Gradient`: Constant gradient
   - `::Vector{<:Gradient}`: Time-varying gradient
 """
-struct RF{T<:Real,G<:Union{<:Gradient,<:AbstractVector{<:Gradient}}} <: AbstractRF
+struct RF{T<:Real, G<:Union{<:Gradient,<:AbstractVector{<:Gradient}}} <: AbstractRF
     α::Vector{T}
     θ::Vector{T}
     Δt::Float64
@@ -73,7 +77,8 @@ struct RF{T<:Real,G<:Union{<:Gradient,<:AbstractVector{<:Gradient}}} <: Abstract
 end
 
 # waveform in Gauss, Δt in ms
-RF(waveform, Δt, Δθ, grad) = RF(GAMMA .* abs.(waveform) .* (Δt / 1000), angle.(waveform), Δt, Δθ, grad)
+RF(waveform, Δt, Δθ, grad) =
+    RF(GAMMA .* abs.(waveform) .* (Δt / 1000), angle.(waveform), Δt, Δθ, grad)
 RF(waveform, Δt, Δθ::Real) = RF(waveform, Δt, Δθ, Gradient(0, 0, 0))
 RF(waveform, Δt, grad) = RF(waveform, Δt, 0, grad)
 RF(waveform, Δt) = RF(waveform, Δt, 0, Gradient(0, 0, 0))
@@ -94,6 +99,7 @@ end
 
 Base.length(rf::RF) = length(rf.α)
 
+
 """
     duration(rf)
 
@@ -102,6 +108,11 @@ Return the duration (ms) of the RF pulse.
 duration(::InstantaneousRF) = 0 # COV_EXCL_LINE
 duration(rf::RF) = length(rf) * rf.Δt
 
+
+"""
+    ExcitationWorkspace
+Struct for in-place operations.
+"""
 struct ExcitationWorkspace{T1,T2,T3,T4,T5}
     Af::T1
     Bf::T2
@@ -147,6 +158,7 @@ function ExcitationWorkspace(
 
 end
 
+
 """
     rotatetheta!(A, α, θ)
 
@@ -188,6 +200,7 @@ function rotatetheta!(A, α, θ)
 
 end
 
+
 """
     rotatetheta(α::Real = π/2, θ::Real = 0)
 
@@ -221,17 +234,22 @@ function rotatetheta(α::Real = π/2, θ::Real = 0)
 
 end
 
+
 """
     excite(spin, rf::InstantaneousRF, [nothing])
     excite(spin, rf::RF, [workspace])
 
-Simulate excitation for the given spin. Returns `(A, B)` such that `A * M + B`
-applies excitation to the magnetization `M`. If `isnothing(B)` (as is the case
-for `InstantaneousRF`s), then `A * M` applies excitation to `M`.
+Simulate excitation for the given spin.
+Returns `(A, B)` such that `A * M + B`
+applies excitation to the magnetization `M`.
+If `isnothing(B)` (as is the case for `InstantaneousRF`s),
+then `A * M` applies excitation to `M`.
 
-For `RF` objects, `workspace isa ExcitationWorkspace`. For `SpinMC` objects, use
-`workspace = ExcitationWorkspace(spin, nothing)` to use an approximate matrix
-exponential to solve the Bloch-McConnell equation.
+For `RF` objects, `workspace isa ExcitationWorkspace`.
+For `SpinMC` objects, use
+`workspace = ExcitationWorkspace(spin, nothing)`
+to use an approximate matrix exponential
+to solve the Bloch-McConnell equation.
 
 For an in-place version, see [`excite!`](@ref).
 
@@ -258,12 +276,13 @@ function excite(spin::AbstractSpin, rf::InstantaneousRF, ::Nothing = nothing)
 
 end
 
+
 """
     excite!(A, [nothing], spin, rf::InstantaneousRF, [nothing])
     excite!(A, B, spin, rf::RF, [workspace])
 
-Simulate excitation, overwriting `A` and `B` (in-place version of
-[`excite`](@ref)).
+Simulate excitation, overwriting `A` and `B`
+(in-place version of [`excite`](@ref)).
 """
 function excite!(A::ExcitationMatrix, spin::AbstractSpin, rf::InstantaneousRF)
 
@@ -293,6 +312,20 @@ function excite(spin::AbstractSpin, rf::RF, workspace = ExcitationWorkspace(spin
 
 end
 
+
+"""
+    excite!(A, B, spin, rf, workspace)
+
+Mutate `A` and `B`
+for an RF pulse described by a vector of samples
+with time step `rf.Δt`.
+The method used here treats each sample
+as free precession for Δt/2,
+followed by instantaneous RF,
+followed by another free precession for Δt/2,
+todo [cite?]
+The accuracy of this method depends on Δt.
+"""
 function excite!(
     A::Union{<:BlochMatrix,<:BlochMcConnellMatrix},
     B::Union{<:Magnetization,<:MagnetizationMC},
@@ -326,6 +359,7 @@ function excite!(
     end
 
 end
+
 
 """
     excite!(spin, ...)

--- a/test/blochmatrix.jl
+++ b/test/blochmatrix.jl
@@ -1,11 +1,15 @@
+# blochmatrix.jl
+
 using BlochSim
 using LinearAlgebra: I, norm
-using Test: @inferred, @test, @testset
+using Test: @inferred, @test, @testset, @test_throws
 
 function blochmatrix1()
 
     A = @inferred BlochMatrix()
     B = @inferred BlochMatrix(0.0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+    @test_throws MethodError BlochMatrix(1, 2, 3) # need 9 scalars
 
     show(devnull, "text/plain", A)
     @test eltype(A) == eltype(B)
@@ -39,6 +43,10 @@ end
 function make_identity1()
 
     A = BlochMatrix(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    @test A == BlochMatrix((1:9)...) # construct from NTuple
+    M = Matrix(A)
+    @test A == BlochMatrix(M) # construct from Matrix
+
     BlochSim.make_identity!(A)
     @test Matrix(A) == I(3)
 


### PR DESCRIPTION
This is a stepping stone to further exploration.

Fixes legend for the exchange plot, adds some docstrings and some BlochMatrix helpers and tests.