### PR TITLE
Finite RF duration via `excite_bloch3`

### DIFF
--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -67,7 +67,7 @@ Examine effects of finite RF pulse duration
 for a single spin with a relatively short T2.
 =#
 
-Mz0, T1_ms, T2_ms, Δf_Hz = 1, 400, 40, 0 # tissue parameters
+Mz0, T1_ms, T2_ms, Δf_Hz = 1, 400, 10, 0 # tissue parameters
 α_deg = 50 # flip angle
 TR_ms, TE_ms, α_rad = 8, 4, deg2rad(α_deg) # scan parameters
 spin = Spin(Mz0, T1_ms, T2_ms, Δf_Hz)
@@ -132,6 +132,7 @@ A1, B1 = excite(spin, rf1)
 A2, B2 = excite(spin, rf2)
 @assert !(Matrix(A1) ≈ Matrix(A2)) # huh!?
 Matrix(A1) - Matrix(A2)
+
 
 #src todo: study more
 #src @which excite(spin, rf2) see excite!(A, ...) with "todo" in excite.jl

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -133,12 +133,26 @@ A2, B2 = excite(spin, rf2)
 @assert !(Matrix(A1) ≈ Matrix(A2)) # huh!?
 Matrix(A1) - Matrix(A2)
 
+using BlochSim: duration, freeprecess
+using LinearAlgebra: I
+(Afp0, dfp0) = freeprecess(spin, TR_ms - duration(rf0))
+(Afp2, dfp2) = freeprecess(spin, TR_ms - duration(rf2))
+At0 = Matrix(A0 * Afp0)
+At2 = Matrix(A2 * Afp2)
+Mss0 = (I - At0) \ Vector(A0 * dfp0)
+Mss2 = (I - At2) \ Vector(A2 * dfp2 + B2)
+
+bs0 = bssfp(spin, TR_ms, duration(rf0)/2, 0, rf0) # signal right after RF
+bs2 = bssfp(spin, TR_ms, duration(rf2)/2, 0, rf2)
+@assert bs0 ≈ complex(Mss0[1], Mss0[2])
+@assert bs2 ≈ complex(Mss2[1], Mss2[2])
+@assert !(bs0 ≈ bs2) # these differ, as expected
 
 #src todo: study more
 #src @which excite(spin, rf2) see excite!(A, ...) with "todo" in excite.jl
 
 #=
-todo: A1 and A2 differ, so why are is signal0 ≈ signal2
+todo: A1 and A2 differ, so why is signal0 ≈ signal2
 =#
 
 

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -102,6 +102,7 @@ signal1 = _bssfp(rf1)
 @assert signal0 ≈ signal1 # should be essentially identical
 @assert α_rad == rf0.α ≈ only(rf1.α)
 
+#throw()
 
 #=
 ### Test 2ms RF pulse

--- a/docs/lit/examples/bssfp-rf-dur.jl
+++ b/docs/lit/examples/bssfp-rf-dur.jl
@@ -47,11 +47,12 @@ end
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using BlochSim: Spin, SpinMC, InstantaneousRF, RF, excite
-using BlochSim: bssfp, GAMMA
+using BlochSim: bssfp, GAMMA, expm_bloch3, excite_bloch3
 #src import ForwardDiff # todo: later
 using MIRTjim: prompt
 using Plots: gui, plot, plot!, default
-default(titlefontsize = 10, markerstrokecolor = :auto, label="", width = 1.5)
+default(titlefontsize = 10, markerstrokecolor = :auto, label="", width = 1.5,
+    linewidth=2)
 
 
 # The following line is helpful when running this file as a script;
@@ -67,17 +68,17 @@ Examine effects of finite RF pulse duration
 for a single spin with a relatively short T2.
 =#
 
-Mz0, T1_ms, T2_ms, Δf_Hz = 1, 400, 10, 0 # tissue parameters
-α_deg = 50 # flip angle
+Mz0, T1_ms, T2_ms, Δf_Hz = 1, 400, 10, 9 # tissue parameters
+α_deg = 50 # flip angle °
 TR_ms, TE_ms, α_rad = 8, 4, deg2rad(α_deg) # scan parameters
 spin = Spin(Mz0, T1_ms, T2_ms, Δf_Hz)
 
 Δϕ_rad = range(-1, 1, 101) * π # phase-cycling factors
-_bssfp(Δϕ, rf) = bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ, rf)
-_bssfp(rf) = map(Δϕ -> _bssfp(Δϕ, rf), Δϕ_rad) # helper
+_bssfp(TE_ms, Δϕ, rf) = bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ, rf)
+_bssfp(TE_ms, rf) = map(Δϕ -> _bssfp(TE_ms, Δϕ, rf), Δϕ_rad) # helper
 
 rf0 = InstantaneousRF(α_rad)
-signal0 = _bssfp(rf0) # signal for InstantaneousRF
+signal0te = _bssfp(TE_ms, rf0); # signal for InstantaneousRF at TE
 
 
 """
@@ -89,34 +90,58 @@ Return finite-duration (rectangular) RF pulse amplitude
   `α_rad = GAMMA * b1_gauss * tRF_s`
 - so `b1_gauss = α_rad / GAMMA / tRF_s`
 """
-b1_gauss(α_rad, tRF_ms) = α_rad / GAMMA / (tRF_ms / 1000)
+b1_gauss(α_rad, tRF_ms) = α_rad / GAMMA / (tRF_ms / 1000);
+
+# helper to make 1-sample RF "waveforms"
+function RF1(α_rad, tRF_ms)
+    waveform = [1] * b1_gauss(α_rad, tRF_ms) # single sample "waveform"
+    return RF(waveform, tRF_ms)
+end;
 
 
 #=
 ### Test "nearly instantaneous" RF pulse
 =#
-tRF_ms = 1e-12 # super-short for first test
-waveform1 = [1] * b1_gauss(α_rad, tRF_ms) # single sample, i.e., "instant"
-rf1 = RF(waveform1, tRF_ms)
-signal1 = _bssfp(rf1)
-@assert signal0 ≈ signal1 # should be essentially identical
+rf1 = RF1(α_rad, 1e-12) # super-short for first test
+signal1te = _bssfp(TE_ms, rf1)
+@assert signal0te ≈ signal1te # should be essentially identical
 @assert α_rad == rf0.α ≈ only(rf1.α)
 
-#throw()
 
 #=
 ### Test 2ms RF pulse
 Somewhat unexpectedly (to JF),
-the signal matches the `InstantaneousRF` case,
-because `excite!` for a `RF` type uses `freeprecess!`
-for each sample and here there is just a single sample.
+the bSSFP signal matches the `InstantaneousRF` case.
+
+The default `BlochSim.excite!`
+uses a "cascade" approximation
+that treats each RF sample as:
+- free precession for Δt/2
+- instantaneous RF rotation
+- free precession for Δt/2.
+
+By the time we reach TE = TR/2,
+apparently this approximation
+yields the same transverse magnetization
+as an instantaneous RF pulse!
 =#
-tRF_ms = 2
-waveform2 = [1] * b1_gauss(α_rad, tRF_ms) # single sample, i.e., "instant!?"
-rf2 = RF(waveform2, tRF_ms)
-signal2 = _bssfp(rf2)
-@assert signal0 ≈ signal2 # todo: matches!?
+rf2 = RF1(α_rad, 2) # 2 ms tRF_ms
+signal2te = _bssfp(TE_ms, rf2)
+@assert signal0te ≈ signal2te # matches!?
 @assert α_rad == rf0.α ≈ only(rf2.α)
+
+
+#=
+In contrast,
+immediately after the RF pulse,
+the signal for the 2 ms RF pulse
+differs from that of the instantaneous RF.
+=#
+signal0rf = _bssfp(Val(:postRF), 0, rf0)
+signal1rf = _bssfp(Val(:postRF), 0, rf1)
+signal2rf = _bssfp(Val(:postRF), 0, rf2)
+@assert signal0rf ≈ signal1rf
+@assert !(signal0rf ≈ signal2rf)
 
 
 #=
@@ -126,12 +151,60 @@ for different RF types.
 A0, B0 = excite(spin, rf0)
 A1, B1 = excite(spin, rf1)
 @assert B0 === nothing
-@assert maximum(abs, Vector(B1)) ≤ 3e-15 # 15*eps()
+@assert maximum(abs, Vector(B1)) ≤ 1e-14 # 15*eps()
 @assert Matrix(A0) ≈ Matrix(A1) # similar as expected for super-short RF
 
 A2, B2 = excite(spin, rf2)
-@assert !(Matrix(A1) ≈ Matrix(A2)) # huh!?
-Matrix(A1) - Matrix(A2)
+@assert Matrix(A1) ≉ Matrix(A2) # differ, as expected
+@assert Vector(B1) ≉ Vector(B2)
+
+
+#=
+### RectRF excitation approximation
+
+Examine the approximation error
+of the "cascade" approximation
+compared to the "exact" 3×3 Bloch matrix exponential
+`expm_bloch3`
+for rectangular RF pulses
+of various durations
+(with zero gradient for simplicity).
+=#
+
+# Instantaneous case reveals a π/2 difference
+w0 = 2π * (Δf_Hz/1000) # rad/ms
+Δϕ_rad0 = 0
+E0 = expm_bloch3(0, 0, 0*w0, # must ignore Δf₀ for this test
+    α_rad * sin(Δϕ_rad0+π/2), α_rad * cos(Δϕ_rad0+π/2), 1)
+@assert E0 ≈ Matrix(A0)
+
+r1_kHz = 1 / spin.T1
+r2_kHz = 1 / spin.T2
+
+tRF_list = range(0.02, 5, 250)
+errora = similar(tRF_list)
+errorb = similar(tRF_list)
+for (i, tRF) in enumerate(tRF_list)
+    rf = RF1(α_rad, tRF) # single sample RF waveform
+    (E3, b3) = excite_bloch3(r1_kHz, r2_kHz, w0,
+        α_rad/tRF * sin(Δϕ_rad0+π/2), α_rad/tRF * cos(Δϕ_rad0+π/2), tRF)
+    Ae, Be = excite(spin, rf)
+    errora[i] = maximum(abs, Matrix(Ae) - E3)
+    errorb[i] = maximum(abs, Vector(Be) - b3)
+end
+plot(title =
+ "Cascade approximation vs expm for M₀=$Mz0 T₁=$T1_ms T₂=$T2_ms Δf=$Δf_Hz Hz",
+    xaxis = ("RF duration [ms]", (0,5), ),
+    yaxis = ("Max-norm error", ),
+)
+plot!(tRF_list, errora, label = "Excitation matrix 'A' error")
+plot!(tRF_list, 10errorb, label = "'b' vector error × 10")
+
+#
+prompt()
+
+#=
+WIP
 
 using BlochSim: duration, freeprecess
 using LinearAlgebra: I
@@ -143,40 +216,44 @@ Mss0 = (I - At0) \ Vector(A0 * dfp0)
 Mss2 = (I - At2) \ Vector(A2 * dfp2 + B2)
 
 bs0 = bssfp(spin, TR_ms, duration(rf0)/2, 0, rf0) # signal right after RF
+@assert bs0 == bssfp(spin, TR_ms, Val(:postRF), 0, rf0) # signal right after RF
 bs2 = bssfp(spin, TR_ms, duration(rf2)/2, 0, rf2)
+@assert bs2 == bssfp(spin, TR_ms, Val(:postRF), 0, rf2)
 @assert bs0 ≈ complex(Mss0[1], Mss0[2])
 @assert bs2 ≈ complex(Mss2[1], Mss2[2])
 @assert !(bs0 ≈ bs2) # these differ, as expected
-
-#src todo: study more
-#src @which excite(spin, rf2) see excite!(A, ...) with "todo" in excite.jl
-
-#=
-todo: A1 and A2 differ, so why is signal0 ≈ signal2
 =#
 
 
 # Plot
 xaxis = ("phase cycling increment Δϕ (rad)", (-π, π), ((-1:1).*π, ["-π", "0", "π"]))
-prfm = plot( ; xaxis, ylabel = "bSSFP signal mag",)
-prfa = plot( ; xaxis, ylabel = "bSSFP signal phase",)
-
-plot!(prfm, Δϕ_rad, abs.(signal0), label="Instantaneous")
-plot!(prfa, Δϕ_rad, angle.(signal0), label="Instantaneous")
+prfm = plot( ; xaxis, ylabel = "bSSFP signal mag", legend=:top)
+prfa = plot( ; xaxis, ylabel = "bSSFP signal phase",);
 
 #src plot!(Δϕ_rad, abs.(signal1), label="tRF = $tRF_ms")
 nw = 1000 # approximately 1μs dwell time
-for tRF_ms in [1e-2 1 2]
-    waveform4 = ones(nw) * b1_gauss(α_rad, tRF_ms)
-    rf4 = RF(waveform4, tRF_ms / nw)
-    @assert rf0.α ≈ sum(rf4.α)
-    signal4 = _bssfp(rf4)
+for tRF_ms in [2 1 1e-2]
+    waveform = ones(nw) * b1_gauss(α_rad, tRF_ms)
+    rf = RF(waveform, tRF_ms / nw)
+    @assert rf0.α ≈ sum(rf.α)
+    signal4te = _bssfp(TE_ms, rf)
     label = "tRF = $tRF_ms ms, nw=$nw"
-    plot!(prfm, Δϕ_rad, abs.(signal4); label)
-    plot!(prfa, Δϕ_rad, angle.(signal4); label)
+    plot!(prfm, Δϕ_rad, abs.(signal4te); label)
+    plot!(prfa, Δϕ_rad, angle.(signal4te); label)
 end;
 
-prf = plot(prfm, prfa, layout=(2,1),
- plot_title = "RF pulse duration effect, T2=$T2_ms (ms)")
+plot!(prfm, Δϕ_rad, abs.(signal0te), label="Instantaneous", line=:dash)
+plot!(prfa, Δϕ_rad, angle.(signal0te), label="Instantaneous", line=:dash);
 
-#src todo include("../../../inc/reproduce.jl")
+prf = plot(prfm, prfa, layout=(2,1),
+ plot_title = "RF pulse duration effect, T2=$T2_ms (ms), Δf₀=$Δf_Hz (Hz)")
+
+#
+prompt()
+
+#=
+### Effect on qMRI
+todo
+=#
+
+#src include("../../../inc/reproduce.jl")

--- a/src/bssfp.jl
+++ b/src/bssfp.jl
@@ -151,20 +151,20 @@ end
 
 """
     function bssfp(spin, TR_ms, TE_ms, Δϕ_rad, rf::AbstractRF)
-Signal accounting for  phase cycling increment `Δϕ_rad`,
+Signal accounting for phase cycling increment `Δϕ_rad`,
 allowing for finite duration `rf` pulse.
 """
 function bssfp(spin,
     TR_ms::Number, TE_ms::Number, Δϕ_rad::Number, rf::AbstractRF,
 )
 
-    (A0, d0) = excite(spin, rf) # matrix for spin excitation
+    (A1, b1) = excite(spin, rf) # matrix for spin excitation
 
     tRF_ms = duration(rf)
-    (A1, d1) = freeprecess(spin, TR_ms - tRF_ms)
+    (A0, d0) = freeprecess(spin, TR_ms - tRF_ms)
     Rz = FreePrecessionMatrix(1, 1, -Δϕ_rad) # phase cycling
-    b = isnothing(d0) ? Vector(A0 * d1) : Vector(A0 * d1 + d0)
-    A = Matrix(A0 * A1 * Rz)
+    b = isnothing(b1) ? Vector(A1 * d0) : Vector(A1 * d0 + b1)
+    A = Matrix(A1 * A0 * Rz)
     Mss = (I - A) \ b # steady-state magnetization immediately after RF
 
     # account for free precession from end of RF to TE:

--- a/src/bssfp.jl
+++ b/src/bssfp.jl
@@ -25,12 +25,28 @@ const bSSFPbloch = bSSFPmode{:Bloch}()
 const bSSFPellipse = bSSFPmode{:Ellipse}()
 
 
+TE_ms_type = Any # Union{Number, Val{:midTR}, Val{:postRF}}
+
+"""
+    _TE_ms(TE_ms, TR_ms, [rf])
+
+Helper to convert TE symbols to a number
+- `Val{:midTR}` for the usual TR/2 choice
+- `Val{:postRF}` immediately after RF pulse ends
+"""
+_TE_ms(TE_ms::Number, TR_ms::Number, args...) = TE_ms
+_TE_ms(::Val{:midTR}, TR_ms::Number, args...) = TR_ms / 2
+_TE_ms(::Val{:postRF}, TR_ms::Number, args...) = 0
+_TE_ms(::Val{:postRF}, TR_ms::Number, rf::AbstractRF) = duration(rf) / 2
+
+
 """
     bssfp(bSSFPellipse, Mz0, T1_ms, T2_ms, Δf_Hz,
        TR_ms, TE_ms, Δϕ_rad, α_rad, θ_rf_rad=0)
 
 Elliptical signal model for bSSFP.
-This is the analytical solution to the 1-pool bSSFP signal.
+This is the analytical solution to the 1-pool bSSFP signal
+with instantaneous RF.
 
 Xiang et al. MRM 2014;
 https://doi.org/10.1002/mrm.25098
@@ -40,9 +56,10 @@ https://doi.org/10.1109/TMI.2021.3102852
 """
 function bssfp(::bSSFPmode{:Ellipse},
     Mz0::Number, T1_ms::Number, T2_ms::Number, Δf_Hz::Number,
-    TR_ms::Number, TE_ms::Number, Δϕ_rad::Number,
+    TR_ms::Number, TE_ms::TE_ms_type, Δϕ_rad::Number,
     α_rad::Number, θ_rf_rad::Number = 0,
 )
+    TE_ms = _TE_ms(TE_ms, TR_ms) # handle Val
     s, c = sincos(α_rad)
     E1 = exp(-TR_ms / T1_ms)
     E2 = exp(-TR_ms / T2_ms)
@@ -99,7 +116,7 @@ bssfp(::bSSFPmode{:Bloch}, args...) = bssfp(args...)
 
 function bssfp(
     Mz0::Number, T1_ms::Number, T2_ms::Number, Δf_Hz::Number,
-    TR_ms::Number, TE_ms::Number, Δϕ_rad::Number,
+    TR_ms::Number, TE_ms::TE_ms_type, Δϕ_rad::Number,
     α_rad::Number, θ_rf_rad::Number = 0,
 )
     rf = InstantaneousRF(α_rad, θ_rf_rad)
@@ -108,12 +125,13 @@ end
 
 function bssfp(
     Mz0::Number, T1_ms::Number, T2_ms::Number, Δf_Hz::Number,
-    TR_ms::Number, TE_ms::Number, Δϕ_rad::Number,
+    TR_ms::Number, TE_ms::TE_ms_type, Δϕ_rad::Number,
     rf::AbstractRF,
     pos::Position = Position(0.0, 0.0, 0.0),
 )
+    TE_ms = _TE_ms(TE_ms, TR_ms, rf) # handle Val
     tRF_ms = duration(rf)
-    tRF_ms/2 < TE_ms < TR_ms - tRF_ms/2 ||
+    tRF_ms/2 ≤ TE_ms < TR_ms - tRF_ms/2 ||
         throw("bad TE=$TE_ms for TR=$TR_ms and tRF=$tRF_ms")
     spin = Spin(Mz0, T1_ms, T2_ms, Δf_Hz, pos)
     return bssfp(spin, TR_ms, TE_ms, Δϕ_rad, rf)
@@ -125,8 +143,9 @@ end
 Classic version with no phase cycling increment,
 for `InstantaneousRF` only.
 """
-function bssfp(spin::Spin, TR_ms::Number, TE_ms::Number, rf::AbstractRF)
+function bssfp(spin::Spin, TR_ms::Number, TE_ms::TE_ms_type, rf::AbstractRF)
 
+    TE_ms = _TE_ms(TE_ms, TR_ms, rf) # handle Val
     (R,) = excite(spin, rf) # matrix for spin excitation
     rf isa InstantaneousRF || throw("unsupported")
 
@@ -157,9 +176,10 @@ Signal accounting for phase cycling increment `Δϕ_rad`,
 allowing for finite duration `rf` pulse.
 """
 function bssfp(spin::Spin,
-    TR_ms::Number, TE_ms::Number, Δϕ_rad::Number, rf::AbstractRF,
+    TR_ms::Number, TE_ms::TE_ms_type, Δϕ_rad::Number, rf::AbstractRF,
 )
 
+    TE_ms = _TE_ms(TE_ms, TR_ms, rf) # handle Val
     (A1, b1) = excite(spin, rf) # matrix for spin excitation
 
     tRF_ms = duration(rf)
@@ -178,16 +198,14 @@ function bssfp(spin::Spin,
 end
 
 
-# helpers for special TE values (TR/2 or right after RF)
-bssfp(spin::Spin, TR_ms::Number, ::Val{:midTR}, Δϕ_rad::Number, rf::AbstractRF) =
-    bssfp(spin, TR_ms, TR_ms/2, Δϕ_rad, rf)
-
-bssfp(spin::Spin, TR_ms::Number, ::Val{:postRF}, Δϕ_rad::Number, rf::AbstractRF) =
-    bssfp(spin, TR_ms, duration(rf)/2, Δϕ_rad, rf)
-
-
+"""
+    bSSFPtuple1
+Named tuple tissue parameter keys:
+`(:Mz0, :T1_ms, :T2_ms, :Δf_Hz)`
+"""
 bSSFPtuple1 = (:Mz0, :T1_ms, :T2_ms, :Δf_Hz)
 
+# helpers
 bssfp(xt::NamedTuple{bSSFPtuple1}, args...) = bssfp(xt..., args...)
 bssfp(::bSSFPmode{:Ellipse}, xt::NamedTuple{bSSFPtuple1}, args...) =
     bssfp(bSSFPellipse, xt..., args...)

--- a/src/bssfp.jl
+++ b/src/bssfp.jl
@@ -62,6 +62,8 @@ end
     bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ_rad, α_rad, θ_rf_rad=0)
     bssfp(Mz0, T1_ms, T2_ms, Δf_Hz, TR_ms, TE_ms, Δϕ_rad, rf, [pos])
     bssfp(spin, Δf_Hz, TR_ms, TE_ms, Δϕ_rad, rf)
+    bssfp(spin, Δf_Hz, TR_ms, Val(:midTR) or Val(:postRF), Δϕ_rad, rf)
+    `Val(:midTR)` for TE = TR/2;  Val(:postRF) for TE = tRF/2
 
 Return steady-state magnetization signal value
 at the echo time
@@ -121,9 +123,9 @@ end
 """
     function bssfp(spin, TR_ms, TE_ms, rf::AbstractRF)
 Classic version with no phase cycling increment,
-for InstantaneousRF only.
+for `InstantaneousRF` only.
 """
-function bssfp(spin, TR_ms::Number, TE_ms::Number, rf::AbstractRF)
+function bssfp(spin::Spin, TR_ms::Number, TE_ms::Number, rf::AbstractRF)
 
     (R,) = excite(spin, rf) # matrix for spin excitation
     rf isa InstantaneousRF || throw("unsupported")
@@ -154,7 +156,7 @@ end
 Signal accounting for phase cycling increment `Δϕ_rad`,
 allowing for finite duration `rf` pulse.
 """
-function bssfp(spin,
+function bssfp(spin::Spin,
     TR_ms::Number, TE_ms::Number, Δϕ_rad::Number, rf::AbstractRF,
 )
 
@@ -174,6 +176,14 @@ function bssfp(spin,
         exp(-t_free_ms / spin.T2) * # T2 decay
         cis(-2π/1000*spin.Δf*t_free_ms) # off resonance
 end
+
+
+# helpers for special TE values (TR/2 or right after RF)
+bssfp(spin::Spin, TR_ms::Number, ::Val{:midTR}, Δϕ_rad::Number, rf::AbstractRF) =
+    bssfp(spin, TR_ms, TR_ms/2, Δϕ_rad, rf)
+
+bssfp(spin::Spin, TR_ms::Number, ::Val{:postRF}, Δϕ_rad::Number, rf::AbstractRF) =
+    bssfp(spin, TR_ms, duration(rf)/2, Δϕ_rad, rf)
 
 
 bSSFPtuple1 = (:Mz0, :T1_ms, :T2_ms, :Δf_Hz)

--- a/src/bssfp.jl
+++ b/src/bssfp.jl
@@ -36,7 +36,7 @@ Helper to convert TE symbols to a number
 """
 _TE_ms(TE_ms::Number, TR_ms::Number, args...) = TE_ms
 _TE_ms(::Val{:midTR}, TR_ms::Number, args...) = TR_ms / 2
-_TE_ms(::Val{:postRF}, TR_ms::Number, args...) = 0
+_TE_ms(::Val{:postRF}, TR_ms::Number, args...) = 0 # COV_EXCL_LINE
 _TE_ms(::Val{:postRF}, TR_ms::Number, rf::AbstractRF) = duration(rf) / 2
 
 

--- a/src/excite.jl
+++ b/src/excite.jl
@@ -76,12 +76,14 @@ struct RF{T<:Real, G<:Union{<:Gradient,<:AbstractVector{<:Gradient}}} <: Abstrac
     end
 end
 
+
 # waveform in Gauss, Δt in ms
 RF(waveform, Δt, Δθ, grad) =
     RF(GAMMA .* abs.(waveform) .* (Δt / 1000), angle.(waveform), Δt, Δθ, grad)
 RF(waveform, Δt, Δθ::Real) = RF(waveform, Δt, Δθ, Gradient(0, 0, 0))
 RF(waveform, Δt, grad) = RF(waveform, Δt, 0, grad)
 RF(waveform, Δt) = RF(waveform, Δt, 0, Gradient(0, 0, 0))
+
 
 Base.show(io::IO, rf::RF) = print(io, "RF(", rf.α, ", ", rf.θ, ", ", rf.Δt, ", ", rf.Δθ_initial, ", ", rf.grad, ")")
 
@@ -111,7 +113,7 @@ duration(rf::RF) = length(rf) * rf.Δt
 
 """
     ExcitationWorkspace
-Struct for in-place operations.
+Struct for in-place excitation operations.
 """
 struct ExcitationWorkspace{T1,T2,T3,T4,T5}
     Af::T1
@@ -319,12 +321,16 @@ end
 Mutate `A` and `B`
 for an RF pulse described by a vector of samples
 with time step `rf.Δt`.
+
 The method used here treats each sample
-as free precession for Δt/2,
-followed by instantaneous RF,
-followed by another free precession for Δt/2,
-todo [cite?]
-The accuracy of this method depends on Δt.
+using a "cascade" of three simpler steps:
+- free precession for Δt/2
+- instantaneous RF rotation
+- free precession for Δt/2
+todo [cite?].
+The accuracy of this "cascade" approximation
+depends on Δt,
+as explored in one of the repo demos.
 """
 function excite!(
     A::Union{<:BlochMatrix,<:BlochMcConnellMatrix},
@@ -334,27 +340,29 @@ function excite!(
     workspace::ExcitationWorkspace = ExcitationWorkspace(spin)
 ) where {T,G}
 
+    w = workspace # shorthand
     Δtby2 = rf.Δt / 2
+    # precompute free precession term for Δt / 2, i.e., F₁^½
     if G <: AbstractVector
-        freeprecess!(workspace.Af, workspace.Bf, spin, Δtby2, rf.grad[1], workspace.bm_workspace)
+        freeprecess!(w.Af, w.Bf, spin, Δtby2, rf.grad[1], w.bm_workspace)
     else
-        freeprecess!(workspace.Af, workspace.Bf, spin, Δtby2, rf.grad, workspace.bm_workspace)
+        freeprecess!(w.Af, w.Bf, spin, Δtby2, rf.grad, w.bm_workspace)
     end
-    excite!(workspace.Ae, spin, InstantaneousRF(rf.α[1], rf.θ[1] + rf.Δθ[]))
+    excite!(w.Ae, spin, InstantaneousRF(rf.α[1], rf.θ[1] + rf.Δθ[])) # R₁
 
-    combine!(workspace.tmpA1, workspace.tmpB1, workspace.Af, workspace.Bf, workspace.Ae, nothing)
-    combine!(A, B, workspace.tmpA1, workspace.tmpB1, workspace.Af, workspace.Bf)
+    combine!(w.tmpA1, w.tmpB1, w.Af, w.Bf, w.Ae, nothing) # F₁^½ R₁
+    combine!(A, B, w.tmpA1, w.tmpB1, w.Af, w.Bf) # F₁^½ R₁ F₁^½
 
-    for t = 2:length(rf)
+    for t in 2:length(rf)
 
-        if G <: AbstractVector
-            freeprecess!(workspace.Af, workspace.Bf, spin, Δtby2, rf.grad[t], workspace.bm_workspace)
+        if G <: AbstractVector # new Fₜ^½ for vector of RF samples
+            freeprecess!(w.Af, w.Bf, spin, Δtby2, rf.grad[t], w.bm_workspace)
         end
-        excite!(workspace.Ae, spin, InstantaneousRF(rf.α[t], rf.θ[t] + rf.Δθ[]))
+        excite!(w.Ae, spin, InstantaneousRF(rf.α[t], rf.θ[t] + rf.Δθ[])) # Rₜ
 
-        combine!(workspace.tmpA1, workspace.tmpB1, A, B, workspace.Af, workspace.Bf)
-        combine!(workspace.tmpA2, workspace.tmpB2, workspace.tmpA1, workspace.tmpB1, workspace.Ae, nothing)
-        combine!(A, B, workspace.tmpA2, workspace.tmpB2, workspace.Af, workspace.Bf)
+        combine!(w.tmpA1, w.tmpB1, A, B, w.Af, w.Bf) # Fₜ^½ effect
+        combine!(w.tmpA2, w.tmpB2, w.tmpA1, w.tmpB1, w.Ae, nothing) # Rₜ effect
+        combine!(A, B, w.tmpA2, w.tmpB2, w.Af, w.Bf) # Fₜ^½ effect
 
     end
 

--- a/src/expm-bloch3.jl
+++ b/src/expm-bloch3.jl
@@ -5,12 +5,13 @@ where A is the 3×3 Bloch matrix (for a constant RF and gradient amplitude),
 using an explicit eigendecomposition
 based on analytical roots of cubic characteristic polynomial.
 
-This code was developed with the help of GPT 5.2.
+The analytical eigendecomposition part of this code
+was developed with the help of GPT 5.2.
 =#
 
-using LinearAlgebra: cond, norm, Diagonal, lu!, mul!, rdiv!
+using LinearAlgebra: cond, norm, Diagonal, lu!, mul!, ldiv!, rdiv!
 
-export expm_bloch3, expm_bloch3!
+export expm_bloch3, expm_bloch3!, excite_bloch3, excite_bloch3!
 
 const Breal = Number # Real or ForwardDiff.Dual
 
@@ -44,12 +45,16 @@ struct Bloch3ExpmWorkspace{T <: Breal}
     λ::Vector{Complex{T}}
     V::Matrix{Complex{T}} # eigenvectors of A
     VD::Matrix{Complex{T}} # V * Diagonal(exp.(λ * t))
+    A::Matrix{T} # for excite
+    d::Vector{T} # for excite
 end
 
 # constructor
 Bloch3ExpmWorkspace{T}() where {T <: Breal} = Bloch3ExpmWorkspace(
     ntuple(_ -> Vector{Complex{T}}(undef, 3), 4)...,
     ntuple(_ -> Matrix{Complex{T}}(undef, 3, 3), 2)...,
+    Matrix{T}(undef, 3, 3),
+    Vector{T}(undef, 3),
 )
 
 
@@ -71,6 +76,21 @@ end
 
 
 """
+    matrix_bloch3!(mat, r1, r2, w, s, c)
+
+Mutating version of `matrix_bloch3()`
+"""
+function matrix_bloch3!(mat::Matrix{T},
+     r1::T, r2::T, w::T, s::T, c::T,
+) where {T <: Breal}
+    mat[1,1], mat[1,2], mat[1,3] = -r2,  w,  s
+    mat[2,1], mat[2,2], mat[2,3] = -w, -r2,  c
+    mat[3,1], mat[3,2], mat[3,3] = -s, -c, -r1
+    return mat
+end
+
+
+"""
     matrix_bloch3(r1, r2, w, s, c)
 
 Return 3×3 Bloch matrix
@@ -78,10 +98,11 @@ Return 3×3 Bloch matrix
       -w  -r2  c;
       -s  -c  -r1]`
 """
-matrix_bloch3(r1::T, r2::T, w::T, s::T, c::T) where {T <: Breal} = [
-    -r2  w   s;
-    -w  -r2  c;
-    -s  -c  -r1]
+function matrix_bloch3(r1::T, r2::T, w::T, s::T, c::T) where {T <: Breal}
+    mat = Matrix{T}(undef, 3, 3)
+    matrix_bloch3!(mat, r1, r2, w, s, c)
+    return mat
+end
 
 
 """
@@ -159,12 +180,12 @@ end
 
 
 """
-    eigvec_3x3!(v, row1, row2, row3, [rtol = 1e-12])
+    eigvec_3by3!(v, row1, row2, row3, [rtol = 1e-12])
 Compute eigenvector `v` by crossing two rows;
 switch row pairs if needed.
 Mutates `v` and workspace `row1` `row2` `row3`
 """
-function eigvec_3x3!(
+function eigvec_3by3!(
     v::AbstractVector{Complex{T}},
     row1::Vector{Complex{T}},
     row2::Vector{Complex{T}},
@@ -203,7 +224,7 @@ function eigvec_bloch3!(
     fill3!(row1, -r2-λ, w,     s)
     fill3!(row2, -w,   -r2-λ,  c)
     fill3!(row3, -s,   -c,   -r1-λ)
-    eigvec_3x3!(v, row1, row2, row3, rtol)
+    eigvec_3by3!(v, row1, row2, row3, rtol)
     return v
 end
 
@@ -298,6 +319,11 @@ Uses explicit eigendecomposition
 based on analytical roots of cubic characteristic polynomial.
 Mutates `expAt` and `work::Bloch3ExpmWorkspace`.
 Allocates very little memory; just some `lu!` overhead.
+
+Caution.
+There is a π/2 difference
+between this code and `excite!`
+as seen in one of the demos.
 """
 function expm_bloch3!(
     expAt::Matrix{Te},
@@ -364,4 +390,52 @@ function expm_bloch3(
     work = Bloch3ExpmWorkspace{T}()
     expm_bloch3!(expAt, work, T(r1), T(r2), T(w), T(s), T(c), T(t))
     return expAt
+end
+
+
+"""
+    excite_bloch3!(...)
+Mutating version of `excite_bloch3`
+"""
+function excite_bloch3!(
+    expAt::Matrix{Te},
+    b1::AbstractVector{Te},
+    work::Bloch3ExpmWorkspace{Tw},
+    r1::T, r2::T, w::T, s::T, c::T, t::Tt;
+) where {Te <: Breal, Tw <: Breal, T <: Breal, Tt <: Breal}
+
+    expm_bloch3!(expAt, work, r1, r2, w, s, c, t)
+    A = work.A
+    d = work.d
+    d[1], d[2], d[3] = 0, 0, r1
+    matrix_bloch3!(A, r1, r2, w, s, c)
+    F = lu!(A)
+    ldiv!(F, d) # d → A^-1 * d
+    mul!(b1, expAt, d) # exp(A*t) * A^-1 * d
+    b1 .-= d
+    return expAt, b1
+end
+
+
+"""
+    (A1, b1) = excite_bloch3(
+Return solution to Bloch equation
+`A1 = exp(A*t)`
+and
+`b1 = (A1 - I) * (A^{-1} * d)`
+for the 3×3 Bloch matrix
+`A = [-r2 w s; -w -r2 c; -s -c -r1]`
+and
+`d = [0, 0, r1]`
+(i.e., for `M₀ = 1`).
+"""
+function excite_bloch3(
+    r1::T1, r2::T2, w::Tw, s::Ts, c::Tc, t::Tt;
+) where {T1 <: Breal, T2 <: Breal, Tw <: Breal, Ts <: Breal, Tc <: Breal, Tt <: Breal}
+    T = promote_type(T1, T2, Tw, Ts, Tc, Tt, Float32)
+    expAt = Matrix{T}(undef, 3, 3)
+    work = Bloch3ExpmWorkspace{T}()
+    b1 = Vector{T}(undef, 3)
+    excite_bloch3!(expAt, b1, work, T(r1), T(r2), T(w), T(s), T(c), T(t))
+    return (expAt, b1)
 end

--- a/test/bssfp.jl
+++ b/test/bssfp.jl
@@ -2,7 +2,7 @@
 test/bssfp.jl
 =#
 
-using BlochSim: bssfp, Spin, InstantaneousRF
+using BlochSim: bssfp, Spin, InstantaneousRF, duration
 using BlochSim: bSSFPbloch, bSSFPellipse
 using ForwardDiff: ForwardDiff
 import ForwardDiff: derivative, gradient
@@ -69,6 +69,12 @@ end
     rf = InstantaneousRF(α_rad, θ_rf_rad)
     sig3 = @inferred bssfp(spin, TR_ms, TE_ms, Δϕ_rad, rf)
     @test sig1 == sig3
+
+    # helpers
+    bpost = bssfp(spin, TR_ms, duration(rf)/2, 0, rf) # signal right after RF
+    @test bpost == bssfp(spin, TR_ms, Val(:postRF), 0, rf)
+    bmid = bssfp(spin, TR_ms, TR_ms/2, 0, rf)
+    @test bmid == bssfp(spin, TR_ms, Val(:midTR), 0, rf)
 
 end
 

--- a/test/expm-bloch3.jl
+++ b/test/expm-bloch3.jl
@@ -118,6 +118,7 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     b1 = Vector{T}(undef, 3)
     @inferred excite_bloch3!(expAt, b1, work, xp..., t) # warm up
     @test 160 ≥ @allocated excite_bloch3!(expAt, b1, work, xp..., t)
+    @test (expAt, b1) == excite_bloch3(xp..., t)
 
     # 2 repeated roots
     xr2 = (2, 1, 0, 0, 0)

--- a/test/expm-bloch3.jl
+++ b/test/expm-bloch3.jl
@@ -1,7 +1,8 @@
 # expm-bloch3.jl
 
 using BlochSim: expm_bloch3, expm_bloch3!
-using BlochSim: matrix_bloch3, eigvals_bloch3, eigvec_3x3!
+using BlochSim: excite_bloch3, excite_bloch3!
+using BlochSim: matrix_bloch3, matrix_bloch3!, eigvals_bloch3, eigvec_3by3!
 using BlochSim: Bloch3ExpmWorkspace, cross!, eigvec_bloch3!, eigen_bloch3!
 using ExponentialAction: expv
 import ForwardDiff
@@ -33,8 +34,13 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     # helper
     A = @inferred matrix_bloch3(xp...)
 
+    A! = similar(A)
+    @inferred matrix_bloch3!(A!, xp...) # warm-up
+    @test A! == A
+    @test 0 == @allocated matrix_bloch3!(A!, xp...)
 
-    # check eigenvalues
+
+    # eigenvalues
     x1 = (2, 1, 1, 0, 0) # Δ > 0
     x2 = (3, 1, 0, 0, 0.8) # Δ < 0
     @test 0 == @allocated eigvals_bloch3(x1...) # Δ > 0
@@ -47,7 +53,7 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     @test compare_eigs(eig.values, lam3)
 
 
-    # check cross!
+    # cross!
     v = Vector{ComplexF64}(undef, 3)
     a = [0, 1//2, 4f0]
     b = [1.0, 2, complex(3,4)]
@@ -56,18 +62,18 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     @test v ≈ cross(a, b)
 
 
-    # check eigvecs
+    # eigvecs
     row1 = Vector{ComplexF64}(undef, 3)
     row2 = Vector{ComplexF64}(undef, 3)
     row3 = Vector{ComplexF64}(undef, 3)
     v = Vector{ComplexF64}(undef, 3)
 
-    @inferred eigvec_3x3!(v, row1, row2, row3)
-    @test [0, 0, 1] == eigvec_3x3!(v, # code cover case 2
+    @inferred eigvec_3by3!(v, row1, row2, row3)
+    @test [0, 0, 1] == eigvec_3by3!(v, # code cover case 2
         ComplexF64[1, 0, 0], ComplexF64[1, 0, 0], ComplexF64[0, 1, 0])
-    @test [0, 0, 0] == eigvec_3x3!(v, # code cover case 3
+    @test [0, 0, 0] == eigvec_3by3!(v, # code cover case 3
         ComplexF64[0, 0, 0], ComplexF64[0, 0, 0], ComplexF64[1, 0, 0])
-    @test 0 == @allocated eigvec_3x3!(v, row1, row2, row3)
+    @test 0 == @allocated eigvec_3by3!(v, row1, row2, row3)
 
     λ0 = Complex(0f0)
     @inferred eigvec_bloch3!(v, row1, row2, row3, 2, 1//1, 0, 0, 0, λ0)
@@ -77,7 +83,7 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     @test 0 == @allocated eigvec_bloch3!(v, row1, row2, row3, r1, r2, w, s, c, λ0)
 
 
-    # check eigendecomposition
+    # eigendecomposition
     T = Float64
     C = Complex{T}
     work = Bloch3ExpmWorkspace{T}()
@@ -93,7 +99,7 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     @test A ≈ V3 * Diagonal(λ3) * inv(V3)
 
 
-    # check exp
+    # exp
     expAt = Matrix{T}(undef, 3, 3)
     @inferred expm_bloch3!(expAt, work, xp..., t) # warm up
     @test 80 ≥ @allocated expm_bloch3!(expAt, work, xp..., t)
@@ -107,6 +113,11 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     Ev = expv(t, A, I(3))
     @test Ev ≈ E0
 
+
+    # excite
+    b1 = Vector{T}(undef, 3)
+    @inferred excite_bloch3!(expAt, b1, work, xp..., t) # warm up
+    @test 160 ≥ @allocated excite_bloch3!(expAt, b1, work, xp..., t)
 
     # 2 repeated roots
     xr2 = (2, 1, 0, 0, 0)

--- a/test/expm-bloch3.jl
+++ b/test/expm-bloch3.jl
@@ -1,7 +1,7 @@
 # expm-bloch3.jl
 
 using BlochSim: expm_bloch3, expm_bloch3!
-using BlochSim: excite_bloch3, excite_bloch3!
+using BlochSim: excite_bloch3, excite_bloch3!, _TE_ms
 using BlochSim: matrix_bloch3, matrix_bloch3!, eigvals_bloch3, eigvec_3by3!
 using BlochSim: Bloch3ExpmWorkspace, cross!, eigvec_bloch3!, eigen_bloch3!
 using ExponentialAction: expv
@@ -119,6 +119,7 @@ compare_eigs(eig_la::Vector{<:Complex}, eig_b3) =
     @inferred excite_bloch3!(expAt, b1, work, xp..., t) # warm up
     @test 160 ≥ @allocated excite_bloch3!(expAt, b1, work, xp..., t)
     @test (expAt, b1) == excite_bloch3(xp..., t)
+    @test 0 == @inferred _TE_ms(Val(:postRF), Inf)
 
     # 2 repeated roots
     xr2 = (2, 1, 0, 0, 0)


### PR DESCRIPTION
- Add excite_bloch3, excite_bloch3!, matrix_bloch3!`
- Document "cascade" approximation used in `excite!`
- Improve finite RF duration demo
