### PR TITLE
Fix NaN problem with autodiff of angle() by avoiding zero values in RF waveforms

### DIFF
--- a/ext/fit.jl
+++ b/ext/fit.jl
@@ -15,7 +15,6 @@ so we include these helper functions.
 import BlochSim: fit_signal, optimize_multistart # extended here
 
 using ADTypes: AutoForwardDiff
-using LinearAlgebra: norm
 using Optim: optimize, LBFGS
 
 
@@ -71,8 +70,8 @@ end
 
 
 """
-    xmin = fit_signal(model::Function, x0::Array, y::Array)
-    xmin = fit_signal(model::Function, x0fun::Function, y::Array; ntry=10)
+    xmin = fit_signal(model::Function, x0::Array, y::Array; kwargs...)
+    xmin = fit_signal(model::Function, x0fun::Function, y::Array; ntry=10, kwargs...)
 
 Perform nonlinear LS fitting
 `xmin = argmin_x ‖ model(x) - y ‖²`.
@@ -80,13 +79,20 @@ Perform nonlinear LS fitting
 If input initial parameter vector guess `x0` is an `Array`,
 then perform a single optimization.
 Otherwise, use `optimize_multistart` to return the best of `ntry` runs.
+Extra `kwargs` are passed to `optimize_multistart`.
 """
-function fit_signal(model, x0fun, y::AbstractArray; ntry::Integer = 10)
-    cost(x) = abs2(norm(model(x) - y)) # LS cost
-    return optimize_multistart(cost, x0fun; ntry)
+function fit_signal(
+    model,
+    x0fun,
+    y::AbstractArray;
+    ntry::Integer = 10,
+    kwargs...,
+)
+    cost(x) = sum(abs2, model(x) - y) # LS cost
+    return optimize_multistart(cost, x0fun; ntry, kwargs...)
 end
 
-function fit_signal(model, x0::AbstractArray, y::AbstractArray; ntry::Integer = 1)
+function fit_signal(model, x0::AbstractArray, y::AbstractArray; ntry::Integer = 1, kwargs...)
     ntry > 1 && @warn("ntry > 1 pointless when x0 provided")
-    return fit_signal(model, i -> x0, y; ntry)
+    return fit_signal(model, i -> x0, y; ntry, kwargs...)
 end

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,19 @@ julia> signal(spinmc)
 Offers many mutating (in-place) methods for compute efficiency.
 
 
+## Limitations
+
+The RF waveform is stored in magnitude/angle format.
+Because `angle()` is not differentiable at `0`,
+`ForwardDiff` will return `NaN` if one tries to optimize
+the flip angle
+of any pulse with zero values.
+See
+[this issue](https://github.com/MagneticResonanceImaging/BlochSim.jl/issues/84)
+and
+[this PR](https://github.com/MagneticResonanceImaging/BlochSim.jl/pull/86).
+
+
 ## Related Julia package(s)
 
 * [MRIgeneralizedBloch.jl](https://github.com/JakobAsslaender/MRIgeneralizedBloch.jl)

--- a/src/excite.jl
+++ b/src/excite.jl
@@ -78,6 +78,8 @@ end
 
 
 # waveform in Gauss, Δt in ms
+# caution: angle.(waveform) is not differentiable when waveform[i] == 0
+# which leads to NaN issues with ForwardDiff.jacobian
 RF(waveform, Δt, Δθ, grad) =
     RF(GAMMA .* abs.(waveform) .* (Δt / 1000), angle.(waveform), Δt, Δθ, grad)
 RF(waveform, Δt, Δθ::Real) = RF(waveform, Δt, Δθ, Gradient(0, 0, 0))

--- a/src/slice.jl
+++ b/src/slice.jl
@@ -7,11 +7,28 @@ RF and gradient waveforms for slice-selective excitation
 
 export rf_slice
 
+#=
+# utility to check for NaN when testing, per
+# https://discourse.julialang.org/t/diagnosing-nans-from-forwarddiff/16364
+import ForwardDiff
+hasnan(x::Real) = false
+hasnan(x::ForwardDiff.Dual) = any(isnan, ForwardDiff.partials(x))
+hasnan(x::AbstractArray) = any(hasnan, x)
+=#
+
 
 """
-    rf_sinc(α_rad, tRF_ms, Δt_ms, shape, nlobe)
+    rf_sinc(α_rad, tRF_ms, Δt_ms, shape, nlobe; tweak_zero = 1e-7)
 
 Make truncated sinc RF waveform.
+
+By default, any zero values of the `sinc` (before scaling)
+are replaced by `tweak_zero`
+to avoid autodiff problems at zero
+when optimizing B1+ scaling; see
+https://github.com/MagneticResonanceImaging/BlochSim.jl/issues/84
+To preserve the zero values,
+set `tweak_zero = 0`.
 """
 function rf_sinc(
     α_rad::Real,
@@ -19,6 +36,8 @@ function rf_sinc(
     Δt_ms::Real,
     shape::Symbol,
     nlobe::Real,
+    ;
+    tweak_zero::Real = 1e-7,
 )
 
     shape === :sinc || throw("unsupported shape $shape")
@@ -26,6 +45,7 @@ function rf_sinc(
     nsamp * Δt_ms ≈ tRF_ms || @warn("Δt_ms=$Δt_ms does not divide tRF_ms=$tRF_ms")
     t = ((0:(nsamp-1))/nsamp .- 0.5) * tRF_ms # [-tRF_ms/2, tRF_ms/2)
     wave = sinc.(2nlobe * t / tRF_ms)
+    wave[findall(==(0), wave)] .= tweak_zero # avoid angle(0) issues in RF()
     wave .*= nsamp / sum(wave) # make sum to unity
     return wave * b1_gauss(α_rad, tRF_ms) # flip angle
 end
@@ -76,6 +96,7 @@ ignores slew-rate constraints.
 - `slice_width` default 1 cm
 - `rephasing::Bool` include rephasing gradient? default `!isinf(slice_width)`
 - `Δθ` phase passed to `RF`; default 0 radian
+- `tweak_zero` see `rf_sinc`
 
 # Out
 - `rf` a `BlochSim.RF` object
@@ -90,9 +111,11 @@ function rf_slice(
     slice_width::Real = 1, # cm
     rephasing::Bool = !isinf(slice_width),
     Δθ::Real = 0,
+    tweak_zero::Real = 1e-7,
 )
 
-    wave = rf_sinc(α_rad, tRF_ms, Δt_ms, shape, nlobe) # RF waveform
+    shape == :sinc || throw(ArgumentError("shape $shape"))
+    wave = rf_sinc(α_rad, tRF_ms, Δt_ms, shape, nlobe; tweak_zero) # RF waveform
     gz = gz_sinc(tRF_ms, nlobe, slice_width) # gradient amplitude
 
     # RF pulse with constant slice-selection gradient:
@@ -116,9 +139,11 @@ function rf_slice(
     slice_width::Real = 1, # cm
     rephasing::Bool = !isinf(slice_width),
     Δθ::Real = 0,
+    tweak_zero::Real = 1e-7,
 )
 
-    wave = rf_sinc(α_rad, tRF_ms, Δt_ms, shape, nlobe) # RF waveform
+    shape == :sinc || throw(ArgumentError("shape $shape"))
+    wave = rf_sinc(α_rad, tRF_ms, Δt_ms, shape, nlobe; tweak_zero) # RF waveform
     nsamp = length(wave)
     gz = gz_sinc(tRF_ms, nlobe, slice_width) # gradient amplitude
 

--- a/test/bssfp1.jl
+++ b/test/bssfp1.jl
@@ -5,7 +5,7 @@ test/bssfp1.jl 1-pool case
 using BlochSim: bssfp, Spin, InstantaneousRF, duration, real_imag
 using BlochSim: bSSFPbloch, bSSFPbloch3, bSSFPellipse, rf_slice
 using ForwardDiff: ForwardDiff
-import ForwardDiff: derivative, gradient
+import ForwardDiff: derivative, gradient, jacobian
 using Test: @inferred, @test, @testset
 
 
@@ -42,12 +42,24 @@ end
     TR_ms, TE_ms, Δϕ_rad, α_rad, θ_rf_rad = 20, 10, 5f0, π/3, π/5, π/7 # scan
     xs = (; TR_ms, TE_ms, Δϕ_rad, α_rad, θ_rf_rad)
 
+    # long argument list with no structs
     sig1 = @inferred bssfp(xt..., xs...)
     @test sig1 isa Complex{<:AbstractFloat}
 
     sig2 = @inferred bssfp(xt, xs...) # tuple version
     @test sig1 == sig2
 
+    # jacobian thereof
+    fun(xt) = real_imag(bssfp(xt..., xs...))
+    jac = ForwardDiff.jacobian(fun, collect(xt))
+    @test jac isa Matrix{<:AbstractFloat}
+    @test !any(isnan, jac)
+
+    # short vs long form for InstantaneousRF
+    spin = Spin(Mz0, T1_ms, T2_ms, Δf_Hz)
+    rf = InstantaneousRF(α_rad, θ_rf_rad)
+    sig3 = @inferred bssfp(spin, TR_ms, TE_ms, Δϕ_rad, rf)
+    @test sig1 == sig3
 
     # ellipse formula
     sig7 = @inferred bssfp(bSSFPellipse, xt..., xs...)
@@ -56,18 +68,6 @@ end
     sig8 = @inferred bssfp(bSSFPellipse, xt, xs...)
     @test sig7 == sig8
 
-
-    # jacobian
-    fun(xt) = real_imag(bssfp(xt..., xs...))
-    grad = ForwardDiff.jacobian(fun, collect(xt))
-    @test grad isa Matrix{<:AbstractFloat}
-
-    # short vs long form
-    spin = Spin(Mz0, T1_ms, T2_ms, Δf_Hz)
-    rf = InstantaneousRF(α_rad, θ_rf_rad)
-    sig3 = @inferred bssfp(spin, TR_ms, TE_ms, Δϕ_rad, rf)
-    @test sig1 == sig3
-
     # helpers
     bpost = bssfp(spin, TR_ms, duration(rf)/2, 0, rf) # signal right after RF
     @test bpost == bssfp(spin, TR_ms, Val(:postRF), 0, rf)
@@ -75,8 +75,43 @@ end
     @test bmid == bssfp(spin, TR_ms, Val(:midTR), 0, rf)
 
     # slice-select version
-    rf, rephasing = rf_slice(1)
+    Δt_ms = 0.1 # coarse for testing
+    rf, rephasing = rf_slice(1; α_rad, Δt_ms)
     sig4 = @inferred bssfp(spin, TR_ms, TE_ms, Δϕ_rad, (rephasing, rf, rephasing))
+
+    # jacobian of slice-select version
+    funs(xt) = real_imag(bssfp(Spin(xt...),
+        TR_ms, TE_ms, Δϕ_rad, (rephasing, rf, rephasing)))
+    @test real_imag(sig4) == funs(xt)
+    jac = ForwardDiff.jacobian(funs, collect(xt))
+    @test jac isa Matrix{<:AbstractFloat}
+    @test !any(isnan, jac)
+
+    # test with RF constructed (kappa fixed to 1)
+    function _bssfp1(xt)
+        spin1 = Spin(xt...)
+        rf1, rephasing1 = rf_slice(1; α_rad = 1 * α_rad, Δt_ms) # kappa
+        tmp = (rephasing1, rf1, rephasing1)
+        return real_imag(bssfp(spin1, TR_ms, TE_ms, Δϕ_rad, tmp))
+    end
+    @test real_imag(sig4) ≈ _bssfp1(xt)
+    jac1 = ForwardDiff.jacobian(_bssfp1, collect(xt))
+    @test jac1 isa Matrix{<:AbstractFloat}
+    @test !any(isnan, jac1)
+
+    # test jacobian with kappa too
+    function _bssfp1(xk)
+        spin1 = Spin(xk[1:4]...)
+        rf1, rephasing1 = rf_slice(1; α_rad = xk[5] * α_rad, Δt_ms) # kappa
+        tmp = (rephasing1, rf1, rephasing1)
+        return real_imag(bssfp(spin1, TR_ms, TE_ms, Δϕ_rad, tmp))
+    end
+    @test real_imag(sig4) ≈ _bssfp1([xt...; 1])
+    kappa = 0.9
+    xk = [xt...; kappa]
+    jac = ForwardDiff.jacobian(_bssfp1, xk)
+    @test jac isa Matrix{<:AbstractFloat}
+    @test !any(isnan, jac)
 end
 
 


### PR DESCRIPTION
- Finish the changes started by #83 by passing kwargs
- add jacobian tests needed to be sure that autodiff works when optimizing kappa (B1+ scaling)
- replace norm^2 with sum(abs2) to address #85
- add warning to readme
- replace zero values in `rf_sinc` with 1e-7 to address #84

This last fix will suffice for slice profile generated by `rf_sinc` and `rf_slice` but will not help users who provide their own RF waveform with zero values in it and then try to optimize B1+ scaling.  Those users will get NaN values.